### PR TITLE
fix: Stack_register annotation

### DIFF
--- a/arch/arm/ARM_CM3/gcc/port/port.c
+++ b/arch/arm/ARM_CM3/gcc/port/port.c
@@ -27,7 +27,7 @@
 #include "config.h"
 
 struct Stack_register {
-    //automatic stacking
+    //manual stacking
     uint32_t r4;
     uint32_t r5;
     uint32_t r6;
@@ -36,7 +36,7 @@ struct Stack_register {
     uint32_t r9;
     uint32_t r10;
     uint32_t r11;
-    //manual stacking
+    //automatic stacking
     uint32_t r0;
     uint32_t r1;
     uint32_t r2;

--- a/boards/stm32f103c8t6/List/gcc/SparrowRTOS_List/Sparrow/scheduler/schedule.c
+++ b/boards/stm32f103c8t6/List/gcc/SparrowRTOS_List/Sparrow/scheduler/schedule.c
@@ -175,7 +175,7 @@ void ADTListInit(void)
 
 
 struct Stack_register {
-    //automatic stacking
+    //manual stacking
     uint32_t r4;
     uint32_t r5;
     uint32_t r6;
@@ -184,7 +184,7 @@ struct Stack_register {
     uint32_t r9;
     uint32_t r10;
     uint32_t r11;
-    //manual stacking
+    //automatic stacking
     uint32_t r0;
     uint32_t r1;
     uint32_t r2;

--- a/boards/stm32f103c8t6/Rbtree/gcc/SparrowRTOS_RBtree/Sparrow/scheduler/schedule.c
+++ b/boards/stm32f103c8t6/Rbtree/gcc/SparrowRTOS_RBtree/Sparrow/scheduler/schedule.c
@@ -160,7 +160,7 @@ void ADTTreeInit(void)
 
 
 struct Stack_register {
-    //automatic stacking
+    //manual stacking
     uint32_t r4;
     uint32_t r5;
     uint32_t r6;
@@ -169,7 +169,7 @@ struct Stack_register {
     uint32_t r9;
     uint32_t r10;
     uint32_t r11;
-    //manual stacking
+    //automatic stacking
     uint32_t r0;
     uint32_t r1;
     uint32_t r2;
@@ -420,7 +420,7 @@ void CheckTicks(void)
         WakeTicksTree = OverWakeTicksTree;
         OverWakeTicksTree = temp;
     }
-    
+
     rb_node = rb_first(WakeTicksTree);
     if (rb_node == NULL) {
         schedule();

--- a/boards/stm32f103c8t6/Table/gcc/SparrowTable/Sparrow/port/port.c
+++ b/boards/stm32f103c8t6/Table/gcc/SparrowTable/Sparrow/port/port.c
@@ -27,7 +27,7 @@
 #include "config.h"
 
 struct Stack_register {
-    //automatic stacking
+    //manual stacking
     uint32_t r4;
     uint32_t r5;
     uint32_t r6;
@@ -36,7 +36,7 @@ struct Stack_register {
     uint32_t r9;
     uint32_t r10;
     uint32_t r11;
-    //manual stacking
+    //automatic stacking
     uint32_t r0;
     uint32_t r1;
     uint32_t r2;

--- a/boards/stm32f103c8t6/rbtreeEDF/gcc/Sparrow/scheduler/schedule.c
+++ b/boards/stm32f103c8t6/rbtreeEDF/gcc/Sparrow/scheduler/schedule.c
@@ -165,7 +165,7 @@ void ADTTreeInit(void)
 
 
 struct Stack_register {
-    //automatic stacking
+    //manual stacking
     uint32_t r4;
     uint32_t r5;
     uint32_t r6;
@@ -174,7 +174,7 @@ struct Stack_register {
     uint32_t r9;
     uint32_t r10;
     uint32_t r11;
-    //manual stacking
+    //automatic stacking
     uint32_t r0;
     uint32_t r1;
     uint32_t r2;

--- a/docs/中文/代码设计/设计.md
+++ b/docs/中文/代码设计/设计.md
@@ -79,7 +79,7 @@ Class(类)
 公有成员：
     PublicMember member1;
     PublicMember member2;
-    
+
     void (*Init)(   thelist *xlist );
     void (*add)(    thelist *xlist, list_node *newnode );
     void (*remove)( thelist *xlist, list_node *rmnode );
@@ -93,7 +93,7 @@ Class(类)
 
 ```
 void nodeInit() {
-    t_circlet->base.draw = ListnodeInit;  
+    t_circlet->base.draw = ListnodeInit;
 
 }
 ```
@@ -269,7 +269,7 @@ uint8_t GetTaskPriority(TaskHandle_t taskHandle);
 
 ```
 struct Stack_register {
-    //automatic stacking
+    //manual stacking
     uint32_t r4;
     uint32_t r5;
     uint32_t r6;
@@ -278,7 +278,7 @@ struct Stack_register {
     uint32_t r9;
     uint32_t r10;
     uint32_t r11;
-    //manual stacking
+    //automatic stacking
     uint32_t r0;
     uint32_t r1;
     uint32_t r2;

--- a/docs/中文/内核实现/数表版本/调度器.md
+++ b/docs/中文/内核实现/数表版本/调度器.md
@@ -83,7 +83,7 @@ TaskHandle_t TcbTaskTable[configMaxPriority];
 
 ```c
 struct Stack_register {
-    // 硬件自动保存（在异常进入时）
+    // 手动保存
     uint32_t r4;
     uint32_t r5;
     uint32_t r6;
@@ -92,7 +92,7 @@ struct Stack_register {
     uint32_t r9;
     uint32_t r10;
     uint32_t r11;
-    // 手动保存
+    // 硬件自动保存（在异常进入时）
     uint32_t r0;
     uint32_t r1;
     uint32_t r2;

--- a/kernel/table/source/mequeue.c
+++ b/kernel/table/source/mequeue.c
@@ -92,9 +92,6 @@ void WriteToQueue( Queue_struct *queue , uint32_t *buf, uint8_t CurrentTcbPriori
         TableRemove(taskHandle,Block);// Also synchronize with the total blocking state
         TableRemove(taskHandle,Delay);
         TableAdd(taskHandle, Ready);
-        if(uxPriority > CurrentTcbPriority){
-            schedule();
-        }
     }
 
     (queue->MessageNumber)++;
@@ -117,9 +114,6 @@ void ExtractFromQueue( Queue_struct *queue, uint32_t *buf, uint8_t CurrentTcbPri
         TableRemove(taskHandle,Block);// Also synchronize with the total blocking state
         TableRemove(taskHandle,Delay);
         TableAdd(taskHandle, Ready);
-        if(uxPriority > CurrentTcbPriority ){
-            schedule();
-        }
     }
 
     (queue->MessageNumber)--;

--- a/kernel/table/source/sem.c
+++ b/kernel/table/source/sem.c
@@ -67,9 +67,6 @@ uint8_t semaphore_release( Semaphore_Handle semaphore)
         TableRemove(taskHandle,Block);// Also synchronize with the total blocking state
         TableRemove(taskHandle,Delay);
         TableAdd(taskHandle, Ready);
-        if(uxPriority > CurrentTcbPriority){
-            schedule();
-        }
     }
     (semaphore->value)++;
 


### PR DESCRIPTION
这里的注释描述感觉是有些问题的，至少是有歧义的。
在实际发生中断的时候，r0–r3, r12, LR, PC, xPSR寄存器是自动入栈的，r4–r11寄存器是需要手动入栈的。
但是针对struct Stack_register结构体，是只在任务栈初始化的时候才使用的，在任务栈初始化的时候反而是需要对r0, LR, PC, xPSR寄存器显式赋值，给人一种这几个寄存器是需要手动压栈的错觉，其实这里也不是压栈，已经通过将任务栈的栈顶指针移动16个位置的方式进行过寄存器压栈操作了，这里执行的只是赋值动作。
综上，这里的注释是会给人造成误解的。