### PR TITLE
fix rwlock_delete write_acquire

### DIFF
--- a/boards/stm32f103c8t6/List/gcc/SparrowRTOS_List/Sparrow/IPC/RWlock.c
+++ b/boards/stm32f103c8t6/List/gcc/SparrowRTOS_List/Sparrow/IPC/RWlock.c
@@ -90,7 +90,7 @@ void read_release(rwlock_handle rwlock1)
 void write_acquire(rwlock_handle rwlock1)
 {
     semaphore_take(rwlock1->C_guard, 1);
-    rwlock1->active_writer -= 1;
+    rwlock1->active_writer += 1;
     if(rwlock1->reading_reader == 0){
         rwlock1->writing_writer += 1;
         semaphore_release(rwlock1->write);
@@ -120,5 +120,9 @@ void write_release(rwlock_handle rwlock1)
 
 void rwlock_delete(rwlock_handle rwlock1)
 {
+    semaphore_delete(rwlock1->read);
+    semaphore_delete(rwlock1->write);
+    semaphore_delete(rwlock1->W_guard);
+    semaphore_delete(rwlock1->C_guard);
     heap_free(rwlock1);
 }

--- a/boards/stm32f103c8t6/Rbtree/gcc/SparrowRTOS_RBtree/Sparrow/IPC/RWlock.c
+++ b/boards/stm32f103c8t6/Rbtree/gcc/SparrowRTOS_RBtree/Sparrow/IPC/RWlock.c
@@ -90,7 +90,7 @@ void read_release(rwlock_handle rwlock1)
 void write_acquire(rwlock_handle rwlock1)
 {
     semaphore_take(rwlock1->C_guard, 1);
-    rwlock1->active_writer -= 1;
+    rwlock1->active_writer += 1;
     if(rwlock1->reading_reader == 0){
         rwlock1->writing_writer += 1;
         semaphore_release(rwlock1->write);
@@ -120,5 +120,9 @@ void write_release(rwlock_handle rwlock1)
 
 void rwlock_delete(rwlock_handle rwlock1)
 {
+    semaphore_delete(rwlock1->read);
+    semaphore_delete(rwlock1->write);
+    semaphore_delete(rwlock1->W_guard);
+    semaphore_delete(rwlock1->C_guard);
     heap_free(rwlock1);
 }

--- a/boards/stm32f103c8t6/Table/gcc/SparrowTable/Sparrow/source/RWlock.c
+++ b/boards/stm32f103c8t6/Table/gcc/SparrowTable/Sparrow/source/RWlock.c
@@ -90,7 +90,7 @@ void read_release(rwlock_handle rwlock1)
 void write_acquire(rwlock_handle rwlock1)
 {
     semaphore_take(rwlock1->C_guard, 1);
-    rwlock1->active_writer -= 1;
+    rwlock1->active_writer += 1;
     if(rwlock1->reading_reader == 0){
         rwlock1->writing_writer += 1;
         semaphore_release(rwlock1->write);
@@ -120,5 +120,9 @@ void write_release(rwlock_handle rwlock1)
 
 void rwlock_delete(rwlock_handle rwlock1)
 {
+    semaphore_delete(rwlock1->read);
+    semaphore_delete(rwlock1->write);
+    semaphore_delete(rwlock1->W_guard);
+    semaphore_delete(rwlock1->C_guard);
     heap_free(rwlock1);
 }

--- a/boards/stm32f103c8t6/rbtreeEDF/gcc/Sparrow/IPC/RWlock.c
+++ b/boards/stm32f103c8t6/rbtreeEDF/gcc/Sparrow/IPC/RWlock.c
@@ -90,7 +90,7 @@ void read_release(rwlock_handle rwlock1)
 void write_acquire(rwlock_handle rwlock1)
 {
     semaphore_take(rwlock1->C_guard, 1);
-    rwlock1->active_writer -= 1;
+    rwlock1->active_writer += 1;
     if(rwlock1->reading_reader == 0){
         rwlock1->writing_writer += 1;
         semaphore_release(rwlock1->write);
@@ -120,5 +120,9 @@ void write_release(rwlock_handle rwlock1)
 
 void rwlock_delete(rwlock_handle rwlock1)
 {
+    semaphore_delete(rwlock1->read);
+    semaphore_delete(rwlock1->write);
+    semaphore_delete(rwlock1->W_guard);
+    semaphore_delete(rwlock1->C_guard);
     heap_free(rwlock1);
 }

--- a/kernel/EDF/source/RWlock.c
+++ b/kernel/EDF/source/RWlock.c
@@ -120,5 +120,9 @@ void write_release(rwlock_handle rwlock1)
 
 void rwlock_delete(rwlock_handle rwlock1)
 {
+    semaphore_delete(rwlock1->read);
+    semaphore_delete(rwlock1->write);
+    semaphore_delete(rwlock1->W_guard);
+    semaphore_delete(rwlock1->C_guard);
     heap_free(rwlock1);
 }

--- a/kernel/list/source/RWlock.c
+++ b/kernel/list/source/RWlock.c
@@ -120,5 +120,9 @@ void write_release(rwlock_handle rwlock1)
 
 void rwlock_delete(rwlock_handle rwlock1)
 {
+    semaphore_delete(rwlock1->read);
+    semaphore_delete(rwlock1->write);
+    semaphore_delete(rwlock1->W_guard);
+    semaphore_delete(rwlock1->C_guard);
     heap_free(rwlock1);
 }

--- a/kernel/rbtree/source/RWlock.c
+++ b/kernel/rbtree/source/RWlock.c
@@ -120,5 +120,9 @@ void write_release(rwlock_handle rwlock1)
 
 void rwlock_delete(rwlock_handle rwlock1)
 {
+    semaphore_delete(rwlock1->read);
+    semaphore_delete(rwlock1->write);
+    semaphore_delete(rwlock1->W_guard);
+    semaphore_delete(rwlock1->C_guard);
     heap_free(rwlock1);
 }

--- a/kernel/table/source/RWlock.c
+++ b/kernel/table/source/RWlock.c
@@ -120,5 +120,9 @@ void write_release(rwlock_handle rwlock1)
 
 void rwlock_delete(rwlock_handle rwlock1)
 {
+    semaphore_delete(rwlock1->read);
+    semaphore_delete(rwlock1->write);
+    semaphore_delete(rwlock1->W_guard);
+    semaphore_delete(rwlock1->C_guard);
     heap_free(rwlock1);
 }


### PR DESCRIPTION
修改了stm32f1版本中write_acquire中active_writer增减，申请写锁时应新增 1 个等待 / 活跃的写者。
修改了rwlock_delete()函数中只释放了结构体自身，没有释放信号量内存的问题。
