### PR TITLE
fix: ensure PCqueue acquisition

### DIFF
--- a/kernel/table/include/PCqueue.h
+++ b/kernel/table/include/PCqueue.h
@@ -27,6 +27,7 @@
 #define PCQUEUE_H
 #include "schedule.h"
 
+#define MAX_WAIT_TICKS (0xFFFF)
 
 typedef struct Oo_buffer *Oo_buffer_handle;
 Oo_buffer_handle Oo_buffer_creat(uint8_t buffer_size);

--- a/kernel/table/source/PCqueue.c
+++ b/kernel/table/source/PCqueue.c
@@ -61,7 +61,7 @@ Oo_buffer_handle Oo_buffer_creat(uint8_t buffer_size)
 
 void Oo_insert(Oo_buffer_handle Oo_buffer1, int object)
 {
-    semaphore_take(Oo_buffer1->space, 1);
+    while(!semaphore_take(Oo_buffer1->space, MAX_WAIT_TICKS));
     Oo_buffer1->buf[Oo_buffer1->in] =  object;
     Oo_buffer1->in = (Oo_buffer1->in + 1) % Oo_buffer1->size;
     semaphore_release(Oo_buffer1->item);
@@ -69,7 +69,7 @@ void Oo_insert(Oo_buffer_handle Oo_buffer1, int object)
 
 int Oo_remove(Oo_buffer_handle Oo_buffer1)
 {
-    semaphore_take(Oo_buffer1->item, 1);
+    while(!semaphore_take(Oo_buffer1->item, MAX_WAIT_TICKS));
     int item1 = Oo_buffer1->buf[Oo_buffer1->out];
     Oo_buffer1->out = (Oo_buffer1->out + 1) % Oo_buffer1->size;
     semaphore_release(Oo_buffer1->space);
@@ -116,9 +116,9 @@ Mo_buffer_handle Mo_buffer_creat(uint8_t buffer_size)
 
 void Mo_insert(Mo_buffer_handle Mo_buffer1, int object)
 {
-    semaphore_take(Mo_buffer1->space, 1);
+    while(!semaphore_take(Mo_buffer1->space, MAX_WAIT_TICKS));
 
-    semaphore_take(Mo_buffer1->guard, 1);
+    while(!semaphore_take(Mo_buffer1->guard, MAX_WAIT_TICKS));
     Mo_buffer1->buf[Mo_buffer1->in] = object;
     Mo_buffer1->in = (Mo_buffer1->in + 1) % Mo_buffer1->size;
     semaphore_release(Mo_buffer1->guard);
@@ -128,7 +128,7 @@ void Mo_insert(Mo_buffer_handle Mo_buffer1, int object)
 
 int Mo_remove(Mo_buffer_handle Mo_buffer1)
 {
-    semaphore_take(Mo_buffer1->item, 1);
+    while(!semaphore_take(Mo_buffer1->item, MAX_WAIT_TICKS));
     int item1 = Mo_buffer1->buf[Mo_buffer1->out];
     Mo_buffer1->out = (Mo_buffer1->out + 1) % Mo_buffer1->size;
     semaphore_release(Mo_buffer1->space);
@@ -177,9 +177,9 @@ Mm_buffer_handle Mm_buffer_creat(uint8_t buffer_size)
 
 void Mm_insert(Mm_buffer_handle Mm_buffer1, int object)
 {
-    semaphore_take(Mm_buffer1->space, 1);
+    while(!semaphore_take(Mm_buffer1->space, MAX_WAIT_TICKS));
 
-    semaphore_take(Mm_buffer1->guard, 1);
+    while(!semaphore_take(Mm_buffer1->guard, MAX_WAIT_TICKS));
     Mm_buffer1->buf[Mm_buffer1->in] =  object;
     Mm_buffer1->in = (Mm_buffer1->in + 1) % Mm_buffer1->size;
     semaphore_release(Mm_buffer1->guard);
@@ -189,9 +189,9 @@ void Mm_insert(Mm_buffer_handle Mm_buffer1, int object)
 
 int Mm_remove(Mm_buffer_handle Mm_buffer1)
 {
-    semaphore_take(Mm_buffer1->item, 1);
+    while(!semaphore_take(Mm_buffer1->item, MAX_WAIT_TICKS));
 
-    semaphore_take(Mm_buffer1->guard, 1);
+    while(!semaphore_take(Mm_buffer1->guard, MAX_WAIT_TICKS));
     int item1 = Mm_buffer1->buf[Mm_buffer1->out];
     Mm_buffer1->out = (Mm_buffer1->out + 1) % Mm_buffer1->size;
     semaphore_release(Mm_buffer1->guard);


### PR DESCRIPTION
与读写锁的解决方式保持一致